### PR TITLE
style: Green background for admin export button

### DIFF
--- a/src/templates/tournaments.html
+++ b/src/templates/tournaments.html
@@ -95,7 +95,7 @@
     <h2>🔒 Site Administration (Admin Only)</h2>
     <p style="margin-bottom: 0.75rem; color: var(--text-muted);">These actions affect <strong>all users and all tournaments</strong> on this site.</p>
     <div class="actions-bar" style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
-        <a href="{{ url_for('api_export_site') }}" class="btn btn-secondary btn-sm">💾 Export Site Backup</a>
+        <a href="{{ url_for('api_export_site') }}" class="btn btn-success btn-sm">💾 Export Site Backup</a>
         <button onclick="document.getElementById('import-site-file').click()" class="btn btn-danger btn-sm">📂 Import Site Backup</button>
     </div>
     <div class="alert alert-error" style="margin-top: 0.75rem;">


### PR DESCRIPTION
Closes #5

Applied green background styling to the site export button in the admin panel. Changed button class from \tn-secondary\ to \tn-success\ to provide visual distinction for the backup export action.

This is a pure CSS styling change with no functional impact.